### PR TITLE
[EXP] explore protein db

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,7 @@ histogram = "0.6.9"
 log = "0.4.17"
 numsep = "0.1.12"
 size = "0.4.0"
-sourmash = { git = "https://github.com/sourmash-bio/sourmash", tag = "mastiff_roaring" }
+sourmash = { git = "https://github.com/sourmash-bio/sourmash", branch = "ntp/mastiff_roaring_prot" }
+
+# use a local copy of the sourmash mastiff branch so I can try editing and/or use the newer code
+#sourmash = { path = "/Users/ntward/dib-lab/sourmash/src/core" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,7 +341,7 @@ fn update<P: AsRef<Path>>(
     info!("Loaded {} sig paths in siglist", index_sigs.len());
 
     let db = RevIndex::open(output.as_ref(), false);
-    db.update(index_sigs, &template, threshold, save_paths);
+    // db.update(index_sigs, &template, threshold, save_paths);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,8 @@ fn build_template(ksize: u8, scaled: usize, moltype: String) -> Sketch {
         "protein" => murmur64_protein,
         _ => panic!("Unknown moltype: {}", moltype),
     };
+    // if protein, multiply ksize by three
+    let ksize = if moltype == "protein" { ksize * 3 } else { ksize };
     let template_mh = KmerMinHash::builder()
         .hash_function(hash_function)
         .num(0u32)


### PR DESCRIPTION
Experimental: try out adding options for using + searching protein signatures.

Initially ran into some issues with `gather`, documented here: https://github.com/bluegenes/2022-06-26-rocksdb-eval/issues/1

I implemented a patch to the sourmash core here: https://github.com/sourmash-bio/sourmash/compare/lirber/mastiff_roaring...ntp/mastiff_roaring_prot?expand=1

...and gather seems to work! Where "work" means it runs and I get an answer returned for the very simple test I'm running, which is just running gather by using one of the signatures that was used to build the database.

 I don't yet understand the implications of this patch, re: whether gather will be accurate or not, to say nothing of efficiency, etc.
more work + testing needed